### PR TITLE
fix tab order after focussing first input

### DIFF
--- a/src/main/java/de/florianreuth/dialogfix/injection/mixin/MixinDialogScreen.java
+++ b/src/main/java/de/florianreuth/dialogfix/injection/mixin/MixinDialogScreen.java
@@ -46,7 +46,8 @@ public abstract class MixinDialogScreen extends Screen {
 
             for (final GuiEventListener guiEventListener : containerWidget.children()) {
                 if (guiEventListener instanceof EditBox || guiEventListener instanceof MultiLineEditBox) {
-                    setFocused(guiEventListener);
+                    containerWidget.setFocused(guiEventListener);
+                    setFocused(containerWidget);
                     break;
                 }
             }


### PR DESCRIPTION
ig that's correct, at least it fixes my issue with the tab order being wrong. Tab did not focus the next button, it focused the  warning button instead. It's now focusing the next button.